### PR TITLE
Fix: Prevent MyPy issue with missing type stub files

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
 basepython = python3.10
 deps =
     -r{toxinidir}/requirements_dev.txt
-commands = mypy src
+commands = mypy --install-types --non-interactive src
 
 [testenv:flake8]
 basepython = python3.10


### PR DESCRIPTION
Related commit in Browserist: https://github.com/jakob-bagterp/browserist/pull/544/commits/b4eb1836401cd3ef4d3c182491f8be9707dd8e2c