### PR TITLE
Fix: Invalid download package URL in Homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ on:
 
 env:
   PACKAGE_NAME: timer-for-python
+  DOWNLOAD_PACKAGE_NAME: timer_for_python
 
 jobs:
   details:
@@ -219,7 +220,7 @@ jobs:
         env:
           FORMULA_NEW_VERSION: ${{ needs.details.outputs.new_version }}
           FORMULA_NAME: ${{ env.PACKAGE_NAME }}
-          FORMULA_URL: https://github.com/${{ github.repository }}/releases/download/v${{ needs.details.outputs.new_version }}/${{ env.PACKAGE_NAME }}-${{ needs.details.outputs.new_version }}.tar.gz
+          FORMULA_URL: https://github.com/${{ github.repository }}/releases/download/v${{ needs.details.outputs.new_version }}/${{ env.DOWNLOAD_PACKAGE_NAME }}-${{ needs.details.outputs.new_version }}.tar.gz
           FORMULA_HOMEBREW_TAP: ${{ github.repository }}
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
This doesn't work: https://github.com/jakob-bagterp/timer-for-python/releases/download/v0.9.0/timer-for-python-0.9.0.tar.gz

This works: https://github.com/jakob-bagterp/timer-for-python/releases/download/v0.9.0/timer_for_python-0.9.0.tar.gz

<img width="1250" alt="Screenshot 2024-12-07 at 22 45 35" src="https://github.com/user-attachments/assets/69e8125d-43fe-42a3-b039-8240bbdc3505">
